### PR TITLE
fix(errors): reading appendChild

### DIFF
--- a/nprogress.js
+++ b/nprogress.js
@@ -240,6 +240,10 @@
           : document.querySelector(Settings.parent),
         spinner
 
+    if(!parent) {
+      parent = document.body
+    }
+    
     css(bar, {
       transition: 'all 0 linear',
       transform: 'translate3d(' + perc + '%,0,0)'
@@ -253,7 +257,7 @@
     if (parent != document.body) {
       addClass(parent, 'nprogress-custom-parent');
     }
-
+    
     parent.appendChild(progress);
     return progress;
   };


### PR DESCRIPTION
Summary:
Fixing the last nprogress error cause this error to be exposed.
Its caused by the parent element being null.  I now check for
null and reassign parent to the body

Test plan:
- test pass

Ref: LOG-12524

Semver: patch